### PR TITLE
fix annotation

### DIFF
--- a/include/gtk-session-lock.h
+++ b/include/gtk-session-lock.h
@@ -73,7 +73,7 @@ struct ext_session_lock_surface_v1 *gtk_session_lock_get_ext_session_lock_surfac
 G_DECLARE_FINAL_TYPE(GtkSessionLockLock, gtk_session_lock_lock, GTK_SESSION_LOCK, LOCK, GObject)
 
 /**
- * gtk_session_lock_manager_prepare_lock:
+ * gtk_session_lock_prepare_lock:
  *
  * Prepare a new #SessionLockLock. You should connect signals to it before
  * calling its lock method.


### PR DESCRIPTION
Fixes the annotations for the  `gtk_session_lock_prepare_lock`, which resulted in this method not being introspected.

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
