### PR TITLE
add examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a library to use [GTK 3](https://www.gtk.org/) to build screen lockers using the secure [ext-session-lock-v1](https://wayland.app/protocols/ext-session-lock-v1) protocol. This Library is compatible with C, C++ and any language that supports GObject introspection files (Python, Vala, etc, see using the library below).
 
-This library is a fork of the incrediable [gtk-layer-shell](https://github.com/wmww/gtk-layer-shell), which has laid all the groundwork necessary to make this happen.
+This library is a fork of the incredible [gtk-layer-shell](https://github.com/wmww/gtk-layer-shell), which has laid all the groundwork necessary to make this happen.
 
 ## Reporting Bugs
 To report a crash or other problem using this library open a new [issue on Github](https://github.com/Cu3PO42/gtk-session-lock/issues). Try to include a minimum reproducer if possible (ideally in C). **DO NOT REPORT GTK SESSION LOCK BUGS TO UPSTREAM GTK**. If you can reproduce the problem without including or linking to the gtk-session-lock library **at all** then and only then report it to GTK instead of here.

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,6 @@
+executable(
+    'simple-example-c',
+    files('simple-example.c'),
+    build_by_default: get_option('examples'),
+    dependencies: [gtk, gtk_session_lock],
+    install: false)

--- a/examples/simple-example.c
+++ b/examples/simple-example.c
@@ -1,0 +1,59 @@
+#include "gtk-session-lock.h"
+#include <gtk/gtk.h>
+#include <stdio.h>
+
+GtkSessionLockLock *lock;
+GtkApplication *app;
+
+static void unlock( GtkWidget *widget, gpointer data) {
+
+    gtk_session_lock_lock_unlock_and_destroy(lock);
+
+    gdk_display_sync(gdk_display_get_default());
+    g_application_quit(G_APPLICATION(app));
+}
+
+static GtkWindow* create_lock_window() {
+    GtkWindow *window = GTK_WINDOW (gtk_application_window_new(app));
+    GtkWidget *entry = gtk_entry_new();
+    gtk_entry_set_visibility(GTK_ENTRY(entry),FALSE);
+    gtk_widget_set_valign(entry, GTK_ALIGN_CENTER);
+    gtk_widget_set_halign(entry, GTK_ALIGN_CENTER);
+
+    gtk_container_add(GTK_CONTAINER(window), entry);
+    
+    g_signal_connect(G_OBJECT(entry), "activate", G_CALLBACK(unlock), NULL);
+
+    return window;
+}
+
+static void activate (GtkApplication* app, void *_data) {
+
+    if (!gtk_session_lock_is_supported()) {
+        printf("Your Wayland compositor does not support the ext-session-lock protocol\n");
+        g_application_quit(G_APPLICATION(app));
+    }
+
+    lock = gtk_session_lock_prepare_lock();
+
+    gtk_session_lock_lock_lock(lock);
+    
+    GdkDisplay *display = gdk_display_get_default();
+    for (int i = 0; i < gdk_display_get_n_monitors(display); ++i) {
+        GdkMonitor *monitor = gdk_display_get_monitor(gdk_display_get_default(), i);
+        
+        GtkWindow *window = create_lock_window();
+        gtk_session_lock_lock_new_surface(lock, window, monitor);
+
+        gtk_widget_show_all(GTK_WIDGET(window));  
+    }
+}
+
+int main (int argc, char **argv) {
+
+    app = gtk_application_new ("Cu3PO42.gtk-session-lock-example", G_APPLICATION_DEFAULT_FLAGS);
+    g_signal_connect (app, "activate", G_CALLBACK (activate), NULL);
+    int status = g_application_run (G_APPLICATION (app), argc, argv);
+    g_object_unref (app);
+    return status;
+}

--- a/examples/simple-example.py
+++ b/examples/simple-example.py
@@ -1,0 +1,35 @@
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('GtkSessionLock', '0.1')
+from gi.repository import Gtk, Gdk, GtkSessionLock
+
+if(not GtkSessionLock.is_supported()):
+    quit()
+
+lock = GtkSessionLock.prepare_lock()
+display = Gdk.Display.get_default()
+
+def unlock(widget):
+    lock.unlock_and_destroy()
+    display.sync()
+    quit()
+
+def create_lock_window():
+    window = Gtk.Window()
+    entry = Gtk.Entry(visibility=False,
+                      valign=Gtk.Align.CENTER,
+                      halign=Gtk.Align.CENTER)
+    entry.connect("activate", unlock)
+    window.add(entry)
+    return window
+
+lock.lock_lock()
+
+for i in range(display.get_n_monitors()):
+    window = create_lock_window()
+    monitor = display.get_monitor(i)
+    lock.new_surface(window, monitor)
+    window.show_all()
+
+
+Gtk.main()

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ gtk_session_lock = declare_dependency(
     link_with: gtk_session_lock_lib,
     include_directories: gtk_session_lock_inc)
 
-#subdir('examples')
+subdir('examples')
 
 if get_option('tests')
     subdir('test')


### PR DESCRIPTION
This PR adds an example in C and in python.

Both examples lock the screen and show only one entry widget per monitor. As soon as the activate signal is emitted on one of those widgets the screen unlocks. These examples do not authenticate the user. This could be added by using pam, if so desired. But the goal of these examples is to demonstrate the usage of this library and therefore omitting authentication in favor of simplicity is preferable.

It also fixes a typo in the readme.

*By opening this pull request, I agree for my modifications to be licensed under whatever licenses are indicated at the start of the files I modified*
